### PR TITLE
Update download script for February 2020 release

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-wget -O ./data/gnaf-latest.zip https://data.gov.au/dataset/19432f89-dc3a-4ef3-b943-5326ef1dbecc/resource/4b084096-65e4-4c8e-abbe-5e54ff85f42f/download/may18gnafpipeseparatedvalue20180521161504.zip
+wget -O ./data/gnaf-latest.zip https://data.gov.au/data/dataset/19432f89-dc3a-4ef3-b943-5326ef1dbecc/resource/4b084096-65e4-4c8e-abbe-5e54ff85f42f/download/feb20_gnaf_pipeseparatedvalue.zip
 mkdir ./data/tmp
 unzip -o ./data/gnaf-latest.zip -d ./data/tmp
 rm -f ./data/*.psv
-mv ./data/tmp/MAY19_GNAF_PipeSeparatedValue_20190521155815/G-NAF/G-NAF\ MAY\ 2019/Authority\ Code/*.psv ./data/
-mv ./data/tmp/MAY19_GNAF_PipeSeparatedValue_20190521155815/G-NAF/G-NAF\ MAY\ 2019/Standard/*.psv ./data/
+mv ./data/tmp/G-NAF/G-NAF\ FEBRUARY\ 2020/Authority\ Code/*.psv ./data/
+mv ./data/tmp/G-NAF/G-NAF\ FEBRUARY\ 2020/Standard/*.psv ./data/
 rm -rf ./data/tmp


### PR DESCRIPTION
This PR updates the download script to pull the February 2020 G-NAF release. Tested locally successfully.